### PR TITLE
Use new autotag arguments variable for empty prefix.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -44,9 +44,10 @@ runs:
         fi
         SHOULD_USE_V_PREFIX=${{ inputs.v-prefix }}
         TAG_PREFIX=""
-        [[ "$SHOULD_USE_V_PREFIX" == 'true' ]] && TAG_PREFIX="v"
+        AUTOTAG_ARGUMENTS="-e"
+        [[ "$SHOULD_USE_V_PREFIX" == 'true' ]] && TAG_PREFIX="v" && AUTOTAG_ARGUMENTS=""
 
-        NEW_VERSION_TAG="${TAG_PREFIX}$(autotag)"
+        NEW_VERSION_TAG="${TAG_PREFIX}$(autotag $AUTOTAG_ARGUMENTS)"
         echo "VERSION_TAG=${NEW_VERSION_TAG}" >> $GITHUB_OUTPUT
     - id: push-tag
       name: Push Tag

--- a/action.yml
+++ b/action.yml
@@ -45,7 +45,10 @@ runs:
         SHOULD_USE_V_PREFIX=${{ inputs.v-prefix }}
         TAG_PREFIX=""
         AUTOTAG_ARGUMENTS="-e"
-        [[ "$SHOULD_USE_V_PREFIX" == 'true' ]] && TAG_PREFIX="v" && AUTOTAG_ARGUMENTS=""
+        if [[ "$SHOULD_USE_V_PREFIX" == 'true' ]]; then
+          TAG_PREFIX="v"
+          AUTOTAG_ARGUMENTS=""
+        fi
 
         NEW_VERSION_TAG="${TAG_PREFIX}$(autotag $AUTOTAG_ARGUMENTS)"
         echo "VERSION_TAG=${NEW_VERSION_TAG}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
From autotag help:

```
Usage:
  autotag [OPTIONS]

Application Options:
  -n                           Just output the next version, don't autotag
  -v                           Enable verbose logging
  -b, --branch=                Git branch to scan (defaults to main, then master)
  -r, --repo=                  Path to the repo (default: ./)
  -p, --pre-release-name=      create a pre-release tag
  -T, --pre-release-timestamp= create a pre-release tag and append a timestamp (can be: datetime|epoch)
  -m, --build-metadata=        optional SemVer build metadata to append to the version with '+' character
  -s, --scheme=                The commit message scheme to use (can be: autotag|conventional) (default: autotag)
  -e, --empty-version-prefix   Do not prepend v to version tag
      --strict-match           Enforce strict mode on the scheme parsers, returns error if no match is found

Help Options:
  -h, --help                   Show this help message

2025/05/29 22:24:49 Usage:
  autotag [OPTIONS]

Application Options:
  -n                           Just output the next version, don't autotag
  -v                           Enable verbose logging
  -b, --branch=                Git branch to scan (defaults to main, then master)
  -r, --repo=                  Path to the repo (default: ./)
  -p, --pre-release-name=      create a pre-release tag
  -T, --pre-release-timestamp= create a pre-release tag and append a timestamp (can be: datetime|epoch)
  -m, --build-metadata=        optional SemVer build metadata to append to the version with '+' character
  -s, --scheme=                The commit message scheme to use (can be: autotag|conventional) (default: autotag)
  -e, --empty-version-prefix   Do not prepend v to version tag
      --strict-match           Enforce strict mode on the scheme parsers, returns error if no match is found

Help Options:
  -h, --help                   Show this help message
```

so we need to pass `-e` for autotag to do what we're expecting; without that, autotag creates a tag with prefix but we try to push it without the prefix so it fails.