### PR TITLE
fix: replace deprecated autotag install script with pinned binary [minor]

### DIFF
--- a/.github/workflows/check-autotag-version.yml
+++ b/.github/workflows/check-autotag-version.yml
@@ -1,0 +1,19 @@
+name: Check autotag version
+
+on:
+  schedule:
+    - cron: '17 14 * * 1' # Weekly on Monday
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: pantheon-systems/action-package-updater@51f94cad4ee60ddcab8918f74f8d1d2d10325f6e # v1.1.19
+        with:
+          dependencies-yml: dependencies.yml

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A GitHub action that implements [autotag-dev/autotag](https://github.com/autotag
 ## What's it do?
 This action will automatically create a new tag and release for your repository when a pull request is merged to the default branch. It will also create a changelog entry for the new tag and release.
 
-Currently configuration is limited (see [source](https://github.com/pantheon-systems/action-autotag/blob/main/src/tag-release.sh)), but in future iterations more configuration options will be added.
+The action pins a specific version of the autotag binary with SHA-256 checksum verification. A [scheduled workflow](.github/workflows/check-autotag-version.yml) checks for new upstream releases weekly and opens a PR when one is available.
 
 ## Inputs
 
@@ -34,6 +34,21 @@ Currently configuration is limited (see [source](https://github.com/pantheon-sys
 |  tag   | string | The tag that was created |
 
 <!-- AUTO-DOC-OUTPUT:END -->
+
+### Updating the pinned autotag version
+
+The autotag binary version and SHA-256 checksum are defined in `action.yml` (env vars `AUTOTAG_VERSION` and `AUTOTAG_SHA256`). The version is also tracked in `dependencies.yml` for automated update detection.
+
+When a new version is available, the scheduled workflow opens a PR bumping `dependencies.yml`. To complete the update:
+
+1. Update `AUTOTAG_VERSION` in `action.yml` to the new version
+2. Fetch the new checksum:
+   ```sh
+   VERSION=v1.4.3  # replace with new version
+   curl -sL "https://github.com/autotag-dev/autotag/releases/download/${VERSION}/autotag_${VERSION#v}_checksums.txt" \
+     | grep 'autotag_linux_amd64$'
+   ```
+3. Update `AUTOTAG_SHA256` in `action.yml` with the hash from step 2
 
 ### Usage
 ```yaml

--- a/action.yml
+++ b/action.yml
@@ -37,11 +37,19 @@ runs:
       name: Tag
       shell: bash
       working-directory: ${{ inputs.workdir }}
+      env:
+        AUTOTAG_VERSION: v1.4.3
+        AUTOTAG_SHA256: 85e7ec97d732800bb838085fd3f2e19b2aa2ee3a8da0db7fd0aaf4113a279f3a
       run: |
-        if ! which autotag > /dev/null; then
-          curl -sL https://git.io/autotag-install | sh --
-          export PATH="$PWD/bin:$PATH"
+        set -euo pipefail
+
+        if ! command -v autotag &>/dev/null; then
+          curl -fsSLo /usr/local/bin/autotag \
+            "https://github.com/autotag-dev/autotag/releases/download/${AUTOTAG_VERSION}/autotag_linux_amd64"
+          echo "${AUTOTAG_SHA256}  /usr/local/bin/autotag" | sha256sum -c -
+          chmod +x /usr/local/bin/autotag
         fi
+
         SHOULD_USE_V_PREFIX=${{ inputs.v-prefix }}
         TAG_PREFIX=""
         AUTOTAG_ARGUMENTS="-e"
@@ -51,7 +59,7 @@ runs:
         fi
 
         NEW_VERSION_TAG="${TAG_PREFIX}$(autotag $AUTOTAG_ARGUMENTS)"
-        echo "VERSION_TAG=${NEW_VERSION_TAG}" >> $GITHUB_OUTPUT
+        echo "VERSION_TAG=${NEW_VERSION_TAG}" >> "$GITHUB_OUTPUT"
     - id: push-tag
       name: Push Tag
       if: ${{ inputs.push-tag == 'true' }}

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -1,0 +1,8 @@
+dependencies:
+  autotag:
+    current_tag: v1.4.3
+    repo: autotag-dev/autotag
+    pr_note: >
+      After merging this version bump, update AUTOTAG_SHA256 in action.yml
+      with the checksum for the new version's `autotag_linux_amd64` binary
+      from the release's checksums.txt file.


### PR DESCRIPTION
## Summary

- Replace the deprecated `curl | sh` install script (via retired `git.io` shortener) with a pinned binary download + SHA-256 checksum verification, as [recommended by upstream](https://github.com/autotag-dev/autotag)
- Pin autotag to `v1.4.3` with verified checksum
- Add a weekly scheduled workflow using `pantheon-systems/action-package-updater` to detect new autotag releases and open PRs automatically
- Update README with maintenance instructions for bumping the pinned version