### PR TITLE
feat: support draft releases via create-release input [minor]

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The action pins a specific version of the autotag binary with SHA-256 checksum v
 
 |           INPUT           |  TYPE  | REQUIRED |  DEFAULT  |                                     DESCRIPTION                                      |
 |---------------------------|--------|----------|-----------|--------------------------------------------------------------------------------------|
-|      create-release       | string |  false   | `"true"`  |        Whether to create a release from <br>the tag or not. 'true', 'false'.         |
+|      create-release       | string |  false   | `"true"`  | Whether to create a release from <br>the tag or not. 'true', 'false', <br>'draft'.   |
 | push-major-version-branch | string |  false   | `"false"` | Push to a branch matching the <br>major version number on the origin <br>repository  |
 |         push-tag          | string |  false   | `"true"`  |                      Push the tag to the origin <br>repository                       |
 |         v-prefix          | string |  false   | `"true"`  |                 Whether to prefix the tag with <br>the letter 'v'.                   |

--- a/README.md
+++ b/README.md
@@ -35,22 +35,7 @@ The action pins a specific version of the autotag binary with SHA-256 checksum v
 
 <!-- AUTO-DOC-OUTPUT:END -->
 
-### Updating the pinned autotag version
-
-The autotag binary version and SHA-256 checksum are defined in `action.yml` (env vars `AUTOTAG_VERSION` and `AUTOTAG_SHA256`). The version is also tracked in `dependencies.yml` for automated update detection.
-
-When a new version is available, the scheduled workflow opens a PR bumping `dependencies.yml`. To complete the update:
-
-1. Update `AUTOTAG_VERSION` in `action.yml` to the new version
-2. Fetch the new checksum:
-   ```sh
-   VERSION=v1.4.3  # replace with new version
-   curl -sL "https://github.com/autotag-dev/autotag/releases/download/${VERSION}/autotag_${VERSION#v}_checksums.txt" \
-     | grep 'autotag_linux_amd64$'
-   ```
-3. Update `AUTOTAG_SHA256` in `action.yml` with the hash from step 2
-
-### Usage
+## Usage
 ```yaml
 name: Autotag and Release
 on:
@@ -70,3 +55,19 @@ jobs:
           fetch-depth: 0
       - uses: pantheon-systems/action-autotag@v1
 ```
+
+## Development
+### Updating the pinned autotag version
+
+The autotag binary version and SHA-256 checksum are defined in `action.yml` (env vars `AUTOTAG_VERSION` and `AUTOTAG_SHA256`). The version is also tracked in `dependencies.yml` for automated update detection.
+
+When a new version is available, the scheduled workflow opens a PR bumping `dependencies.yml`. To complete the update:
+
+1. Update `AUTOTAG_VERSION` in `action.yml` to the new version
+2. Fetch the new checksum:
+   ```sh
+   VERSION=v1.4.3  # replace with new version
+   curl -sL "https://github.com/autotag-dev/autotag/releases/download/${VERSION}/autotag_${VERSION#v}_checksums.txt" \
+     | grep 'autotag_linux_amd64$'
+   ```
+3. Update `AUTOTAG_SHA256` in `action.yml` with the hash from step 2

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
     required: false
     default: true
   create-release:
-    description: "Whether to create a release from the tag or not. 'true', 'false'." # TODO: Support 'draft'
+    description: "Whether to create a release from the tag or not. 'true', 'false', 'draft'."
     required: false
     default: true
   workdir:
@@ -95,4 +95,10 @@ runs:
       env:
         GH_TOKEN: ${{ github.token }}
       run: |
-        gh release create ${{ steps.tag.outputs.VERSION_TAG }} -t ${{ steps.tag.outputs.VERSION_TAG }} --generate-notes
+        DRAFT_FLAG=""
+        if [[ "${{ inputs.create-release }}" == "draft" ]]; then
+          DRAFT_FLAG="--draft"
+        fi
+        gh release create ${{ steps.tag.outputs.VERSION_TAG }} \
+          -t ${{ steps.tag.outputs.VERSION_TAG }} \
+          --generate-notes $DRAFT_FLAG

--- a/action.yml
+++ b/action.yml
@@ -100,10 +100,16 @@ runs:
         VERSION_TAG: ${{ steps.tag.outputs.VERSION_TAG }}
         CREATE_RELEASE: ${{ inputs.create-release }}
       run: |
-        DRAFT_FLAG=""
-        if [[ "$CREATE_RELEASE" == "draft" ]]; then
-          DRAFT_FLAG="--draft"
-        fi
+        DRAFT_FLAG=()
+        case "$CREATE_RELEASE" in
+          true) ;;
+          draft) DRAFT_FLAG+=(--draft) ;;
+          *)
+            echo "::error::Invalid value for create-release: '$CREATE_RELEASE' (expected 'true', 'false', or 'draft')"
+            exit 1
+            ;;
+        esac
         gh release create "$VERSION_TAG" \
           -t "$VERSION_TAG" \
-          --generate-notes $DRAFT_FLAG
+          --generate-notes \
+          "${DRAFT_FLAG[@]}"

--- a/action.yml
+++ b/action.yml
@@ -40,6 +40,7 @@ runs:
       env:
         AUTOTAG_VERSION: v1.4.3
         AUTOTAG_SHA256: 85e7ec97d732800bb838085fd3f2e19b2aa2ee3a8da0db7fd0aaf4113a279f3a
+        V_PREFIX: ${{ inputs.v-prefix }}
       run: |
         set -euo pipefail
 
@@ -50,10 +51,9 @@ runs:
           chmod +x /usr/local/bin/autotag
         fi
 
-        SHOULD_USE_V_PREFIX=${{ inputs.v-prefix }}
         TAG_PREFIX=""
         AUTOTAG_ARGUMENTS="-e"
-        if [[ "$SHOULD_USE_V_PREFIX" == 'true' ]]; then
+        if [[ "$V_PREFIX" == 'true' ]]; then
           TAG_PREFIX="v"
           AUTOTAG_ARGUMENTS=""
         fi
@@ -63,16 +63,19 @@ runs:
     - id: push-tag
       name: Push Tag
       if: ${{ inputs.push-tag == 'true' }}
-      run: git push origin ${{ steps.tag.outputs.VERSION_TAG }}
       working-directory: ${{ inputs.workdir }}
       shell: bash
+      env:
+        VERSION_TAG: ${{ steps.tag.outputs.VERSION_TAG }}
+      run: git push origin "$VERSION_TAG"
     - id: push-major-version-branch
       if: ${{ inputs.push-major-version-branch == 'true' }}
       working-directory: ${{ inputs.workdir }}
       shell: bash
+      env:
+        VERSION_TAG: ${{ steps.tag.outputs.VERSION_TAG }}
       run: |
-        NEW_RELEASE=${{ steps.tag.outputs.VERSION_TAG }}
-        MAJOR_VERSION_BRANCH="v${NEW_RELEASE#v}" # Ensure it is prepended with v
+        MAJOR_VERSION_BRANCH="v${VERSION_TAG#v}"
         MAJOR_VERSION_BRANCH="${MAJOR_VERSION_BRANCH%%.*}"
         echo "Major version: ${MAJOR_VERSION_BRANCH}"
         
@@ -94,11 +97,13 @@ runs:
       working-directory: ${{ inputs.workdir }}
       env:
         GH_TOKEN: ${{ github.token }}
+        VERSION_TAG: ${{ steps.tag.outputs.VERSION_TAG }}
+        CREATE_RELEASE: ${{ inputs.create-release }}
       run: |
         DRAFT_FLAG=""
-        if [[ "${{ inputs.create-release }}" == "draft" ]]; then
+        if [[ "$CREATE_RELEASE" == "draft" ]]; then
           DRAFT_FLAG="--draft"
         fi
-        gh release create ${{ steps.tag.outputs.VERSION_TAG }} \
-          -t ${{ steps.tag.outputs.VERSION_TAG }} \
+        gh release create "$VERSION_TAG" \
+          -t "$VERSION_TAG" \
           --generate-notes $DRAFT_FLAG


### PR DESCRIPTION
## Summary

- Extend the `create-release` input to accept `'draft'` as a value alongside `'true'` and `'false'`
- When set to `'draft'`, the GitHub Release is created with `--draft`, adding a human review step before it becomes visible to consumers
- Addresses item 6 from [SITE-5880](https://getpantheon.atlassian.net/browse/SITE-5880)

[SITE-5880]: https://getpantheon.atlassian.net/browse/SITE-5880?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ