### PR TITLE
test: add bats unit tests and autotag integration suite

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,31 @@
+name: Test
+
+on:
+  pull_request: {}
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  unit:
+    name: Unit (bats)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Install bats
+        run: sudo apt-get update && sudo apt-get install -y bats
+      - name: Shellcheck
+        run: shellcheck scripts/*.sh tests/*.sh
+      - name: Run bats
+        run: bats tests/
+
+  integration:
+    name: Integration (real autotag binary)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Run integration tests
+        run: tests/integration.sh

--- a/Makefile
+++ b/Makefile
@@ -3,4 +3,13 @@
 update-docs:
 	auto-doc -f action.yml
 
-.PHONY: update-docs
+# Unit tests. Requires bats: brew install bats-core
+test:
+	bats tests/
+
+# Integration tests against the real pinned autotag binary. Linux only;
+# on macOS run: docker run --rm -v "$$PWD":/w -w /w ubuntu:24.04 tests/integration.sh
+test-integration:
+	tests/integration.sh
+
+.PHONY: update-docs test test-integration

--- a/README.md
+++ b/README.md
@@ -69,7 +69,31 @@ By default autotag reads `[minor]` / `[major]` markers in commit subjects. To us
           scheme: conventional
 ```
 
+Under this scheme, a major bump is signalled either by a `!` before the colon
+(`feat!:`, `feat(api)!:`) or by a `BREAKING CHANGE:` footer in the commit body,
+which outranks the commit type — a `fix:` with that footer is still a major bump.
+
+> [!NOTE]
+> The Conventional Commits spec also allows a hyphenated `BREAKING-CHANGE:`
+> footer, but autotag v1.4.3 does not recognise it and treats such a commit as a
+> minor bump. Use `BREAKING CHANGE:` (with a space) or the `!` form.
+
 ## Development
+### Tests
+
+| Command | What it covers |
+|---|---|
+| `make test` | Unit tests (bats) for `scripts/build-args.sh` — the autotag argument list built from each input combination. Requires `bats` (`brew install bats-core`). |
+| `make test-integration` | Runs the real pinned autotag binary against throwaway git repos to verify the flags are accepted and produce the expected bumps. Linux only, since the pinned binary is `linux_amd64`. |
+
+On macOS, run the integration suite in a container:
+
+```sh
+docker run --rm -v "$PWD":/w -w /w ubuntu:24.04 tests/integration.sh
+```
+
+Both suites run in CI on every pull request via [`.github/workflows/test.yml`](.github/workflows/test.yml).
+
 ### Updating the pinned autotag version
 
 The autotag binary version and SHA-256 checksum are defined in `action.yml` (env vars `AUTOTAG_VERSION` and `AUTOTAG_SHA256`). The version is also tracked in `dependencies.yml` for automated update detection.

--- a/action.yml
+++ b/action.yml
@@ -60,19 +60,19 @@ runs:
         # asked for a bare version: -e (--empty-version-prefix) tells it not to
         # prepend its own 'v'.
         TAG_PREFIX=""
-        AUTOTAG_ARGUMENTS=(-e)
         if [[ "$V_PREFIX" == 'true' ]]; then
           TAG_PREFIX="v"
         fi
 
-        case "$SCHEME" in
-          '') ;;
-          autotag|conventional) AUTOTAG_ARGUMENTS+=(--scheme "$SCHEME") ;;
-          *)
-            echo "::error::Invalid value for scheme: '$SCHEME' (expected '', 'autotag', or 'conventional')"
-            exit 1
-            ;;
-        esac
+        # Assign the helper's output to a variable first: a failure there is
+        # caught by 'set -e', whereas a failing process substitution is not
+        # and would silently yield an empty argument list.
+        RAW_ARGUMENTS="$("${GITHUB_ACTION_PATH}/scripts/build-args.sh" "$SCHEME")"
+
+        AUTOTAG_ARGUMENTS=()
+        while IFS= read -r arg; do
+          AUTOTAG_ARGUMENTS+=("$arg")
+        done <<< "$RAW_ARGUMENTS"
 
         NEW_VERSION_TAG="${TAG_PREFIX}$(autotag "${AUTOTAG_ARGUMENTS[@]}")"
         echo "VERSION_TAG=${NEW_VERSION_TAG}" >> "$GITHUB_OUTPUT"

--- a/scripts/build-args.sh
+++ b/scripts/build-args.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Build the autotag argument list from the action's inputs.
+#
+# Usage: build-args.sh <scheme>
+#
+# Prints one argument per line so the caller can read it into an array
+# without relying on word splitting. Exits non-zero on an invalid scheme.
+set -euo pipefail
+IFS=$'\n\t'
+
+SCHEME="${1:-}"
+
+# The action applies the 'v' prefix itself, so autotag is always asked for a
+# bare version: -e (--empty-version-prefix) tells it not to prepend its own.
+args=(-e)
+
+# autotag silently accepts an unknown --scheme and falls back to its default
+# bumping, so an unvalidated typo would quietly produce a wrong version.
+case "$SCHEME" in
+  '') ;;
+  autotag|conventional) args+=(--scheme "$SCHEME") ;;
+  *)
+    echo "::error::Invalid value for scheme: '$SCHEME' (expected '', 'autotag', or 'conventional')" >&2
+    exit 1
+    ;;
+esac
+
+printf '%s\n' "${args[@]}"

--- a/tests/build-args.bats
+++ b/tests/build-args.bats
@@ -1,0 +1,72 @@
+#!/usr/bin/env bats
+#
+# Table-driven tests for scripts/build-args.sh.
+
+setup() {
+  BUILD_ARGS="${BATS_TEST_DIRNAME}/../scripts/build-args.sh"
+}
+
+# Each case is: scheme | expected args (newline-escaped)
+@test "builds the expected argument list for every valid scheme" {
+  local cases=(
+    '|-e'
+    'autotag|-e\n--scheme\nautotag'
+    'conventional|-e\n--scheme\nconventional'
+  )
+
+  local failures=0
+  for case in "${cases[@]}"; do
+    local scheme="${case%%|*}"
+    local expected
+    expected="$(printf '%b' "${case#*|}")"
+
+    local actual
+    actual="$("$BUILD_ARGS" "$scheme")"
+
+    if [[ "$actual" != "$expected" ]]; then
+      echo "FAIL: scheme=${scheme}"
+      echo "  expected: $(printf '%q' "$expected")"
+      echo "  actual:   $(printf '%q' "$actual")"
+      failures=$((failures + 1))
+    fi
+  done
+
+  [ "$failures" -eq 0 ]
+}
+
+@test "always passes -e, since the action applies the v prefix itself" {
+  run "$BUILD_ARGS" ""
+  [ "$status" -eq 0 ]
+  [ "$output" = "-e" ]
+}
+
+@test "defaults to no --scheme when the input is omitted entirely" {
+  run "$BUILD_ARGS"
+  [ "$status" -eq 0 ]
+  [ "$output" = "-e" ]
+}
+
+@test "emits --scheme and its value as separate arguments" {
+  # Guards against regressing to a single "--scheme conventional" token,
+  # which autotag would reject as an unknown flag.
+  run "$BUILD_ARGS" "conventional"
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "-e" ]
+  [ "${lines[1]}" = "--scheme" ]
+  [ "${lines[2]}" = "conventional" ]
+  [ "${#lines[@]}" -eq 3 ]
+}
+
+@test "rejects an invalid scheme" {
+  # autotag itself accepts an unknown scheme silently and falls back to
+  # default bumping, so this validation is what turns a typo into a failed
+  # build rather than a wrong version.
+  run "$BUILD_ARGS" "conventionel"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Invalid value for scheme: 'conventionel'"* ]]
+}
+
+@test "rejects a scheme that differs only by case" {
+  run "$BUILD_ARGS" "Conventional"
+  [ "$status" -ne 0 ]
+}

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -1,0 +1,160 @@
+#!/bin/bash
+# Integration tests: run the real, pinned autotag binary against throwaway
+# git repositories to verify the flags we build are actually accepted and
+# produce the version bumps we expect.
+#
+# No mocks and no fixture repo checked into the tree: each case builds its
+# own history in a temp dir and is torn down afterwards.
+set -euo pipefail
+IFS=$'\n\t'
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUILD_ARGS="${REPO_ROOT}/scripts/build-args.sh"
+
+# Pull the pinned version/checksum straight from action.yml so this test can
+# never drift from what the action actually downloads.
+AUTOTAG_VERSION="$(sed -n 's/.*AUTOTAG_VERSION:[[:space:]]*//p' "${REPO_ROOT}/action.yml")"
+AUTOTAG_SHA256="$(sed -n 's/.*AUTOTAG_SHA256:[[:space:]]*//p' "${REPO_ROOT}/action.yml")"
+
+# The pinned binary is linux_amd64, matching the action's own download.
+if [[ "$(uname -s)" != 'Linux' ]]; then
+  echo "This integration test requires Linux (the pinned autotag build is linux_amd64)." >&2
+  echo "Run it in CI, or via: docker run --rm -v \"\$PWD\":/w -w /w ubuntu:24.04 tests/integration.sh" >&2
+  exit 1
+fi
+
+BIN_DIR="$(mktemp -d)"
+trap 'rm -rf "$BIN_DIR"' EXIT
+
+echo "Installing autotag ${AUTOTAG_VERSION}..."
+curl -fsSLo "${BIN_DIR}/autotag" \
+  "https://github.com/autotag-dev/autotag/releases/download/${AUTOTAG_VERSION}/autotag_linux_amd64"
+echo "${AUTOTAG_SHA256}  ${BIN_DIR}/autotag" | sha256sum -c -
+chmod +x "${BIN_DIR}/autotag"
+AUTOTAG="${BIN_DIR}/autotag"
+
+failures=0
+
+# make_repo <commit-subject>...
+# Creates a temp repo tagged v1.2.3, then layers on the given commits.
+make_repo() {
+  local dir
+  dir="$(mktemp -d)"
+  git -C "$dir" init -q -b main
+  git -C "$dir" config user.email test@example.com
+  git -C "$dir" config user.name 'Test'
+  git -C "$dir" commit -q --allow-empty -m 'initial commit'
+  git -C "$dir" tag v1.2.3
+  local subject
+  for subject in "$@"; do
+    git -C "$dir" commit -q --allow-empty -m "$subject"
+  done
+  echo "$dir"
+}
+
+# check <description> <v-prefix> <scheme> <expected-tag> <commit-subject>...
+check() {
+  local desc="$1" v_prefix="$2" scheme="$3" expected="$4"
+  shift 4
+
+  local dir
+  dir="$(make_repo "$@")"
+
+  local raw
+  if ! raw="$("$BUILD_ARGS" "$scheme")"; then
+    echo "FAIL: ${desc}"
+    echo "  build-args.sh rejected scheme '${scheme}'"
+    failures=$((failures + 1))
+    rm -rf "$dir"
+    return
+  fi
+
+  local args=()
+  while IFS= read -r arg; do
+    args+=("$arg")
+  done <<< "$raw"
+
+  local prefix=""
+  [[ "$v_prefix" == 'true' ]] && prefix="v"
+
+  # Run autotag in its real tag-creating mode (no -n), matching what the
+  # action does. stderr is left on the terminal rather than folded into the
+  # compared value, so a warning cannot masquerade as an assertion diff.
+  local actual
+  if ! actual="${prefix}$(cd "$dir" && "$AUTOTAG" "${args[@]}")"; then
+    echo "FAIL: ${desc} (autotag exited non-zero; see stderr above)"
+    failures=$((failures + 1))
+    rm -rf "$dir"
+    return
+  fi
+
+  if [[ "$actual" != "$expected" ]]; then
+    echo "FAIL: ${desc}"
+    echo "  expected: ${expected}"
+    echo "  actual:   ${actual}"
+    failures=$((failures + 1))
+    rm -rf "$dir"
+    return
+  fi
+
+  # The tag must actually exist in the repo, since autotag ran for real.
+  if ! git -C "$dir" rev-parse -q --verify "refs/tags/${actual#v}" >/dev/null &&
+     ! git -C "$dir" rev-parse -q --verify "refs/tags/${actual}" >/dev/null; then
+    echo "FAIL: ${desc}"
+    echo "  autotag reported ${actual} but created no matching tag"
+    failures=$((failures + 1))
+    rm -rf "$dir"
+    return
+  fi
+
+  echo "ok: ${desc} -> ${actual}"
+  rm -rf "$dir"
+}
+
+# With no scheme set, autotag uses its default: patch for an ordinary commit,
+# with [minor]/[major] markers read out of the subject.
+check 'default scheme, patch bump'          true  ''             v1.2.4 'a normal commit'
+check 'default scheme, minor marker'        true  ''             v1.3.0 'add a thing [minor]'
+check 'default scheme, no v prefix'         false ''             1.2.4  'a normal commit'
+
+# An explicit 'autotag' scheme is the same behaviour, named.
+check 'explicit autotag scheme'             true  autotag        v1.2.4 'a normal commit'
+
+# The conventional scheme reads the commit type instead.
+check 'conventional, fix -> patch'          true  conventional   v1.2.4 'fix: correct a thing'
+check 'conventional, feat -> minor'         true  conventional   v1.3.0 'feat: add a thing'
+check 'conventional, breaking -> major'     true  conventional   v2.0.0 'feat!: change a thing'
+check 'conventional, scoped breaking'       true  conventional   v2.0.0 'feat(api)!: change a thing'
+check 'conventional, BREAKING CHANGE footer' true conventional   v2.0.0 'feat: change a thing
+
+BREAKING CHANGE: the response shape changed'
+# A breaking footer outranks the commit type: a fix: is still a major bump.
+check 'conventional, fix with breaking footer' true conventional v2.0.0 'fix: correct a thing
+
+BREAKING CHANGE: the response shape changed'
+# Documented upstream gap: autotag v1.4.3 does NOT honour the hyphenated
+# BREAKING-CHANGE: synonym that the Conventional Commits spec allows, so this
+# is only a minor bump. Pinned here so a future autotag bump surfaces the change.
+check 'conventional, BREAKING-CHANGE not honoured' true conventional v1.3.0 'feat: change a thing
+
+BREAKING-CHANGE: hyphenated synonym is not recognised'
+check 'conventional, no v prefix'           false conventional   1.3.0  'feat: add a thing'
+
+# The schemes must actually differ: a bare "feat:" commit is only a patch
+# bump under the default scheme, which proves the flag is taking effect.
+check 'feat: is only a patch by default'    true  ''             v1.2.4 'feat: add a thing'
+
+# An invalid scheme must fail the build rather than silently falling back.
+echo "checking invalid scheme is rejected..."
+if "$BUILD_ARGS" 'conventionel' >/dev/null 2>&1; then
+  echo "FAIL: invalid scheme 'conventionel' was accepted"
+  failures=$((failures + 1))
+else
+  echo "ok: invalid scheme rejected"
+fi
+
+if [[ "$failures" -gt 0 ]]; then
+  echo "${failures} integration test(s) failed"
+  exit 1
+fi
+echo "All integration tests passed"


### PR DESCRIPTION
Adds the repo's first test CI, covering the autotag argument construction at two levels.

Stacked on #39 (`feat/conventional-commits`) — the diff against that branch is tests plus the extraction that makes them possible. Merge #39 first, then this retargets cleanly to `main`.

## Making the logic testable

The argument construction lived inside `action.yml`'s `run:` block, which cannot be invoked directly. It now lives in `scripts/build-args.sh`, which takes the scheme and prints one argument per line. The path resolves via `$GITHUB_ACTION_PATH` rather than the working directory, since the step runs in `inputs.workdir`.

`action.yml` assigns that output to a variable before splitting it, rather than reading it through a process substitution. This matters: `set -e` does **not** cover process substitution, so a missing or erroring helper would leave an empty argument list and let the step continue — silently dropping `--scheme` and releasing a wrong version. Verified both forms directly:

| Form | Helper missing | Invalid scheme |
|---|---|---|
| `< <(helper)` (rejected) | prints error, **continues, exit 0** | prints error, **continues, exit 0** |
| `raw="$(helper)"` (used) | aborts, exit 127 | aborts, exit 1 |

## Unit tests — `tests/build-args.bats`

Table-driven over every valid scheme value, plus cases pinning that `--scheme` and its value stay two separate argv entries (collapsing them would make autotag reject the flag), that an omitted input is accepted, and that an invalid or wrong-case scheme is rejected.

## Integration tests — `tests/integration.sh`

Runs the real pinned autotag binary against git repos built in temp dirs — no mocks, no fixture repo in the tree. autotag runs in its real tag-creating mode (not `-n` dry-run), and each case asserts the tag was actually created. stderr is kept off the compared value so a warning cannot masquerade as an assertion diff.

| Scheme | Commit | Expected |
|---|---|---|
| default | `a normal commit` | `v1.2.4` |
| default | `add a thing [minor]` | `v1.3.0` |
| `autotag` | `a normal commit` | `v1.2.4` |
| `conventional` | `fix: correct a thing` | `v1.2.4` |
| `conventional` | `feat: add a thing` | `v1.3.0` |
| `conventional` | `feat!: change a thing` | `v2.0.0` |
| `conventional` | `feat(api)!: change a thing` | `v2.0.0` |
| `conventional` | `feat:` + `BREAKING CHANGE:` footer | `v2.0.0` |
| `conventional` | `fix:` + `BREAKING CHANGE:` footer | `v2.0.0` |
| default | `feat: add a thing` | `v1.2.4` |

The last row is the important one: the same commit bumps patch under the default scheme and minor under conventional, so the suite fails if the scheme flag ever stops taking effect.

The script reads `AUTOTAG_VERSION` and `AUTOTAG_SHA256` out of `action.yml` and verifies the checksum, so it always tests the binary the action actually downloads and cannot drift when the pinned version is bumped.

### Pinned upstream gap

The Conventional Commits spec treats `BREAKING-CHANGE:` as a synonym for `BREAKING CHANGE:`, but autotag v1.4.3 does not recognise the hyphenated form and treats such a commit as a *minor* bump. That behaviour is asserted in the suite and documented in the README, so a future autotag bump that fixes it surfaces as a test failure rather than a silent change in release versions.

## CI

`.github/workflows/test.yml` runs both jobs on pull requests, with SHA-pinned actions and read-only permissions to match the existing workflows. shellcheck covers `scripts/` and `tests/`. `make test` and `make test-integration` run them locally.

## Verification

All 6 bats tests and all 13 integration cases pass; the integration suite was run against the real v1.4.3 binary in an `ubuntu:24.04` container. `shellcheck` is clean on both scripts. The integration suite is Linux-only (the pinned build is `linux_amd64`) and exits with an explanatory message elsewhere; the README documents the Docker one-liner for macOS.
