### PR TITLE
fix: keep autotag's -e flag in step with the v-prefix input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -56,22 +56,24 @@ runs:
           chmod +x /usr/local/bin/autotag
         fi
 
-        # The 'v' prefix is applied below via TAG_PREFIX, so autotag is always
-        # asked for a bare version: -e (--empty-version-prefix) tells it not to
-        # prepend its own 'v'.
+        # autotag prints a bare version but creates a tag that is prefixed
+        # unless -e is passed, so build-args.sh keeps that flag in step with
+        # TAG_PREFIX. Otherwise the tag created and the tag pushed disagree.
         TAG_PREFIX=""
         if [[ "$V_PREFIX" == 'true' ]]; then
           TAG_PREFIX="v"
         fi
 
-        RAW_ARGUMENTS="$("${GITHUB_ACTION_PATH}/scripts/build-args.sh" "$SCHEME")"
+        RAW_ARGUMENTS="$("${GITHUB_ACTION_PATH}/scripts/build-args.sh" "$SCHEME" "$V_PREFIX")"
 
         AUTOTAG_ARGUMENTS=()
         while IFS= read -r arg; do
-          AUTOTAG_ARGUMENTS+=("$arg")
+          if [[ -n "$arg" ]]; then
+            AUTOTAG_ARGUMENTS+=("$arg")
+          fi
         done <<< "$RAW_ARGUMENTS"
 
-        NEW_VERSION_TAG="${TAG_PREFIX}$(autotag "${AUTOTAG_ARGUMENTS[@]}")"
+        NEW_VERSION_TAG="${TAG_PREFIX}$(autotag ${AUTOTAG_ARGUMENTS[@]+"${AUTOTAG_ARGUMENTS[@]}"})"
         echo "VERSION_TAG=${NEW_VERSION_TAG}" >> "$GITHUB_OUTPUT"
     - id: push-tag
       name: Push Tag

--- a/scripts/build-args.sh
+++ b/scripts/build-args.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Build the autotag argument list from the action's inputs.
 #
-# Usage: build-args.sh <scheme>
+# Usage: build-args.sh <scheme> <v-prefix>
 #
 # Prints one argument per line so the caller can read it into an array
 # without relying on word splitting. Exits non-zero on an invalid scheme.
@@ -9,10 +9,17 @@ set -euo pipefail
 IFS=$'\n\t'
 
 SCHEME="${1:-}"
+V_PREFIX="${2:-true}"
 
-# The action applies the 'v' prefix itself, so autotag is always asked for a
-# bare version: -e (--empty-version-prefix) tells it not to prepend its own.
-args=(-e)
+args=()
+
+# -e (--empty-version-prefix) controls the prefix on the tag autotag CREATES;
+# the version it prints is bare either way. So -e must track the action's own
+# TAG_PREFIX: pass it only when we do NOT want a 'v', otherwise autotag writes
+# tag '1.2.3' while the action goes on to push 'v1.2.3', which does not exist.
+if [[ "$V_PREFIX" != 'true' ]]; then
+  args+=(-e)
+fi
 
 # autotag silently accepts an unknown --scheme and falls back to its default
 # bumping, so an unvalidated typo would quietly produce a wrong version.
@@ -25,4 +32,9 @@ case "$SCHEME" in
     ;;
 esac
 
-printf '%s\n' "${args[@]}"
+# The array can be empty (v-prefix with no scheme); printf with no arguments
+# would still emit one blank line, which the caller would read as an empty
+# argv entry and autotag would reject.
+if [[ "${#args[@]}" -gt 0 ]]; then
+  printf '%s\n' "${args[@]}"
+fi

--- a/tests/build-args.bats
+++ b/tests/build-args.bats
@@ -1,66 +1,104 @@
 #!/usr/bin/env bats
 #
-# Tests for scripts/build-args.sh, which turns the action's 'scheme' input
-# into the argument list passed to autotag.
+# Tests for scripts/build-args.sh, which turns the action's 'scheme' and
+# 'v-prefix' inputs into the argument list passed to autotag.
 
 setup() {
   BUILD_ARGS="${BATS_TEST_DIRNAME}/../scripts/build-args.sh"
 }
 
-# --- valid schemes -----------------------------------------------------------
+# --- the -e / v-prefix coupling ---------------------------------------------
+#
+# -e (--empty-version-prefix) decides whether the tag autotag CREATES carries a
+# 'v'. The version it prints is bare either way, so -e must track the action's
+# own TAG_PREFIX exactly. Passing -e while the action prefixes 'v' makes
+# autotag write tag '1.2.3' and the action push 'v1.2.3', which does not exist.
 
-@test "empty scheme passes only -e" {
+@test "v-prefix true omits -e so autotag creates the v-prefixed tag" {
+  run "$BUILD_ARGS" "" "true"
+  [ "$status" -eq 0 ]
+  [ "$output" = "" ]
+}
+
+@test "v-prefix false passes -e so autotag creates the bare tag" {
+  run "$BUILD_ARGS" "" "false"
+  [ "$status" -eq 0 ]
+  [ "${#lines[@]}" -eq 1 ]
+  [ "${lines[0]}" = "-e" ]
+}
+
+@test "v-prefix true omits -e for every valid scheme" {
+  local scheme
+  for scheme in "" "autotag" "conventional"; do
+    run "$BUILD_ARGS" "$scheme" "true"
+    [ "$status" -eq 0 ]
+    [ "${lines[0]}" != "-e" ]
+  done
+}
+
+@test "v-prefix defaults to true when omitted" {
   run "$BUILD_ARGS" ""
   [ "$status" -eq 0 ]
-  [ "${#lines[@]}" -eq 1 ]
-  [ "${lines[0]}" = "-e" ]
+  [ "$output" = "" ]
 }
 
-@test "omitted scheme passes only -e" {
+@test "omitted scheme and v-prefix produce no arguments" {
   run "$BUILD_ARGS"
   [ "$status" -eq 0 ]
-  [ "${#lines[@]}" -eq 1 ]
-  [ "${lines[0]}" = "-e" ]
+  [ "$output" = "" ]
 }
 
-@test "autotag scheme passes -e and --scheme autotag" {
-  run "$BUILD_ARGS" "autotag"
+# Any non-'true' value means no 'v', matching the action's own
+# [[ "$V_PREFIX" == 'true' ]] test for TAG_PREFIX.
+@test "a non-true v-prefix value passes -e" {
+  run "$BUILD_ARGS" "" "False"
   [ "$status" -eq 0 ]
-  [ "${#lines[@]}" -eq 3 ]
   [ "${lines[0]}" = "-e" ]
-  [ "${lines[1]}" = "--scheme" ]
-  [ "${lines[2]}" = "autotag" ]
 }
 
-@test "conventional scheme passes -e and --scheme conventional" {
-  run "$BUILD_ARGS" "conventional"
+# --- valid schemes -----------------------------------------------------------
+
+@test "autotag scheme with v-prefix passes only --scheme autotag" {
+  run "$BUILD_ARGS" "autotag" "true"
+  [ "$status" -eq 0 ]
+  [ "${#lines[@]}" -eq 2 ]
+  [ "${lines[0]}" = "--scheme" ]
+  [ "${lines[1]}" = "autotag" ]
+}
+
+@test "conventional scheme with v-prefix passes only --scheme conventional" {
+  run "$BUILD_ARGS" "conventional" "true"
+  [ "$status" -eq 0 ]
+  [ "${#lines[@]}" -eq 2 ]
+  [ "${lines[0]}" = "--scheme" ]
+  [ "${lines[1]}" = "conventional" ]
+}
+
+@test "conventional scheme without v-prefix passes -e and --scheme" {
+  run "$BUILD_ARGS" "conventional" "false"
   [ "$status" -eq 0 ]
   [ "${#lines[@]}" -eq 3 ]
   [ "${lines[0]}" = "-e" ]
   [ "${lines[1]}" = "--scheme" ]
   [ "${lines[2]}" = "conventional" ]
-}
-
-# --e is unconditional because the action applies the 'v' prefix itself via
-# TAG_PREFIX, so autotag is always asked for a bare version. Keeping it
-# unconditional also means the argument array is never empty, which would
-# otherwise trip 'set -u' on bash < 4.4.
-@test "-e is always the first argument" {
-  local scheme
-  for scheme in "" "autotag" "conventional"; do
-    run "$BUILD_ARGS" "$scheme"
-    [ "$status" -eq 0 ]
-    [ "${lines[0]}" = "-e" ]
-  done
 }
 
 # --scheme and its value must stay separate argv entries; collapsing them into
 # a single "--scheme conventional" token makes autotag reject the flag.
 @test "--scheme and its value are separate arguments, not one token" {
-  run "$BUILD_ARGS" "conventional"
+  run "$BUILD_ARGS" "conventional" "true"
   [ "$status" -eq 0 ]
-  [ "${lines[1]}" = "--scheme" ]
-  [ "${lines[2]}" = "conventional" ]
+  [ "${lines[0]}" = "--scheme" ]
+  [ "${lines[1]}" = "conventional" ]
+}
+
+# An empty argument list must print nothing at all. A bare printf would emit
+# one blank line, which the caller reads as an empty argv entry and autotag
+# rejects as an invalid argument.
+@test "empty argument list prints nothing, not a blank line" {
+  run "$BUILD_ARGS" "" "true"
+  [ "$status" -eq 0 ]
+  [ "${#output}" -eq 0 ]
 }
 
 # --- invalid schemes ---------------------------------------------------------
@@ -70,30 +108,30 @@ setup() {
 # rather than a silently wrong release version.
 
 @test "rejects a misspelled scheme" {
-  run "$BUILD_ARGS" "conventionel"
+  run "$BUILD_ARGS" "conventionel" "true"
   [ "$status" -ne 0 ]
   [[ "$output" == *"Invalid value for scheme: 'conventionel'"* ]]
 }
 
 @test "rejects a scheme differing only by case" {
-  run "$BUILD_ARGS" "Conventional"
+  run "$BUILD_ARGS" "Conventional" "true"
   [ "$status" -ne 0 ]
   [[ "$output" == *"Invalid value for scheme:"* ]]
 }
 
 @test "rejects a scheme with surrounding whitespace" {
-  run "$BUILD_ARGS" " conventional"
+  run "$BUILD_ARGS" " conventional" "true"
   [ "$status" -ne 0 ]
 }
 
 @test "rejects an autotag flag passed as a scheme" {
-  run "$BUILD_ARGS" "--strict-match"
+  run "$BUILD_ARGS" "--strict-match" "true"
   [ "$status" -ne 0 ]
   [[ "$output" == *"Invalid value for scheme:"* ]]
 }
 
 @test "error message names the accepted values" {
-  run "$BUILD_ARGS" "nope"
+  run "$BUILD_ARGS" "nope" "true"
   [ "$status" -ne 0 ]
   [[ "$output" == *"expected '', 'autotag', or 'conventional'"* ]]
 }

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -61,7 +61,7 @@ check() {
   dir="$(make_repo "$@")"
 
   local raw
-  if ! raw="$("$BUILD_ARGS" "$scheme")"; then
+  if ! raw="$("$BUILD_ARGS" "$scheme" "$v_prefix")"; then
     echo "FAIL: ${desc}"
     echo "  build-args.sh rejected scheme '${scheme}'"
     failures=$((failures + 1))
@@ -71,7 +71,9 @@ check() {
 
   local args=()
   while IFS= read -r arg; do
-    args+=("$arg")
+    if [[ -n "$arg" ]]; then
+      args+=("$arg")
+    fi
   done <<< "$raw"
 
   local prefix=""
@@ -81,7 +83,7 @@ check() {
   # action does. stderr is left on the terminal rather than folded into the
   # compared value, so a warning cannot masquerade as an assertion diff.
   local actual
-  if ! actual="${prefix}$(cd "$dir" && "$AUTOTAG" "${args[@]}")"; then
+  if ! actual="${prefix}$(cd "$dir" && "$AUTOTAG" ${args[@]+"${args[@]}"})"; then
     echo "FAIL: ${desc} (autotag exited non-zero; see stderr above)"
     failures=$((failures + 1))
     rm -rf "$dir"
@@ -97,11 +99,14 @@ check() {
     return
   fi
 
-  # The tag must actually exist in the repo, since autotag ran for real.
-  if ! git -C "$dir" rev-parse -q --verify "refs/tags/${actual#v}" >/dev/null &&
-     ! git -C "$dir" rev-parse -q --verify "refs/tags/${actual}" >/dev/null; then
+  # The tag autotag CREATED must be exactly the tag the action goes on to
+  # push. Accepting either the prefixed or bare form here is what let the
+  # created-vs-pushed mismatch through: autotag prints a bare version in both
+  # modes, so only the created ref distinguishes them.
+  if ! git -C "$dir" rev-parse -q --verify "refs/tags/${actual}" >/dev/null; then
     echo "FAIL: ${desc}"
-    echo "  autotag reported ${actual} but created no matching tag"
+    echo "  autotag reported ${actual} but created no tag by that name"
+    echo "  tags present: $(git -C "$dir" tag -l | tr '\n' ' ')"
     failures=$((failures + 1))
     rm -rf "$dir"
     return


### PR DESCRIPTION
The v1.3.0 release run on main failed at the Push Tag step with `error: src refspec v1.3.0 does not match any` ([run 33269177314](https://github.com/pantheon-systems/action-autotag/actions/runs/33269177314)). Autotag computed the version fine; the tag it created was not the one the action tried to push.

## Cause

`-e` (`--empty-version-prefix`) controls the prefix on the tag autotag *creates*, not the version it prints — stdout is a bare `1.3.0` in both modes. Verified against the pinned v1.4.3 binary:

| flags | prints | creates |
|---|---|---|
| `autotag` | `1.3.0` | `v1.3.0` |
| `autotag -e` | `1.3.0` | `1.3.0` |

#39 made `-e` unconditional. Previously it was passed only when `v-prefix` was false, so the created tag and the pushed tag agreed. With `-e` always on and the default `v-prefix: true`, autotag creates `1.3.0` while the action pushes `v1.3.0`.

## Fix

`build-args.sh` takes `v-prefix` as a second argument and emits `-e` only when no `v` is wanted, mirroring the action's own `TAG_PREFIX` test. This makes an empty argument list reachable, so the script prints nothing rather than a blank line, callers skip empty entries, and `${arr[@]+...}` keeps an empty array from tripping `set -u`.

No documented behavior changes — the `scheme` input and README are unaffected.

## Why the tests missed it

`tests/integration.sh` ran the real binary in tag-creating mode, but its existence check accepted *either* `refs/tags/1.3.0` or `refs/tags/v1.3.0`, and the compared value came from stdout, which is identical in both modes. The created ref was the only thing that distinguished them, and it was the one thing not asserted.

It now asserts the created tag is exactly the tag the action would push, and prints the tags present on failure. Reverting the fix fails 11 of its 13 cases with the production error:

```
FAIL: conventional, breaking -> major
  autotag reported v2.0.0 but created no tag by that name
  tags present: 2.0.0 v1.2.3
```

The bats suite covers the coupling directly: `-e` absent for every scheme when `v-prefix` is true, present when it is not, and an empty argument list printing no blank line.